### PR TITLE
Ratelimit on the actual req

### DIFF
--- a/ratelimit/clock/clock.go
+++ b/ratelimit/clock/clock.go
@@ -1,14 +1,17 @@
+// A fancy stopwatch that monitors the rate we fill ratelimit.jar.Jar
 package clock
 
 import (
 	"time"
 )
 
-func FillRate(limit, seconds int) time.Duration {
+// Figures out the pace to fill the bucket.
+func FillRate(maxLimit, seconds int) time.Duration {
 	ms := time.Duration(seconds) * time.Second
-	return ms / time.Duration(limit)
+	return ms / time.Duration(maxLimit)
 }
 
+// Basic timer that helps monitor the rate we fill the bucket
 type Clock interface {
 	Finish() error
 	Tick() <-chan time.Time

--- a/ratelimit/jar/jar.go
+++ b/ratelimit/jar/jar.go
@@ -2,10 +2,10 @@
 package jar
 
 type Jar interface {
-    // Give something to the jar
+	// Give something to the jar
 	Give()
-    // Take something from the jar
+	// Take something from the jar
 	Take()
-    // Check to see if the jar is full
+	// Check to see if the jar is full
 	Full() bool
 }

--- a/ratelimit/jar/jar.go
+++ b/ratelimit/jar/jar.go
@@ -1,7 +1,11 @@
+// Our "bucket" that is sometimes leaky.
 package jar
 
 type Jar interface {
+    // Give something to the jar
 	Give()
+    // Take something from the jar
 	Take()
+    // Check to see if the jar is full
 	Full() bool
 }

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -5,19 +5,19 @@ package ratelimit
 // ApiClient uses Limiter as the main way to ratelimit requests.
 // It manages all the limiters inside
 type Limiter interface {
-    // Start rate limiting
+	// Start rate limiting
 	Activate()
-    // Stop rate limiting
+	// Stop rate limiting
 	Deactivate()
-    // Add a new Limit into Limiter
+	// Add a new Limit into Limiter
 	Add(int, Limit)
-    // Take a token from a specific Limit
+	// Take a token from a specific Limit
 	Take(index int)
 }
 
 type Limit interface {
-    // Fills the  bucket usually at a fixed rate
+	// Fills the  bucket usually at a fixed rate
 	Recharge()
-    // Take a value from the bucket. Should wait if there are no values to get
+	// Take a value from the bucket. Should wait if there are no values to get
 	Take()
 }

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,14 +1,23 @@
+// The ratelimit package limits the number requests made toward the api.
+// Based on the leaky bucket algorithm
 package ratelimit
 
+// ApiClient uses Limiter as the main way to ratelimit requests.
+// It manages all the limiters inside
 type Limiter interface {
+    // Start rate limiting
 	Activate()
+    // Stop rate limiting
 	Deactivate()
-
+    // Add a new Limit into Limiter
 	Add(int, Limit)
-	Take(int)
+    // Take a token from a specific Limit
+	Take(index int)
 }
 
 type Limit interface {
+    // Fills the  bucket usually at a fixed rate
 	Recharge()
+    // Take a value from the bucket. Should wait if there are no values to get
 	Take()
 }

--- a/riot/client.go
+++ b/riot/client.go
@@ -35,10 +35,6 @@ func (rc *RiotClient) NewRequest(uri string) (req ApiRequest) {
 		uri: uri,
 	}
 
-	if rc.rateLimitEnabled {
-		rc.limiter.Take(int(rc.region))
-	}
-
 	return req
 }
 
@@ -53,12 +49,14 @@ func (rc *RiotClient) Get(req ApiRequest) (resp *http.Response, err error) {
 		RawQuery: req.Encode(),
 	}
 
-	var e error
-	if resp, e = get(u); e != nil {
-		err = errors.NewErrorFromString(e.Error())
+	if rc.rateLimitEnabled {
+		rc.limiter.Take(int(rc.region))
 	}
 
-	fmt.Println("Get", err)
+	if resp, err = get(u); err != nil {
+		err = errors.NewErrorFromString(err.Error())
+	}
+
 	return resp, err
 
 }
@@ -116,6 +114,5 @@ func get(u *url.URL) (resp *http.Response, err error) {
 		return resp, err
 	}
 
-	fmt.Println("get", err)
 	return resp, err
 }

--- a/riot/riot.go
+++ b/riot/riot.go
@@ -8,15 +8,16 @@ import (
 	"github.com/coltiebaby/g-law/ratelimit"
 	"github.com/coltiebaby/g-law/ratelimit/clock"
 	"github.com/coltiebaby/g-law/ratelimit/jar"
-	"github.com/coltiebaby/g-law/riot/errors"
 )
 
 var (
 	c = config.FromEnv()
 	// Client = NewClient(REGION_NA, c.EnableRateLimiting)
-	Client = NewClient(REGION_NA, c.EnableRateLimiting)
+	Client ApiClient = NewRiotClient(REGION_NA, c.EnableRateLimiting)
 )
 
+// SetupRateLimit creates a new Default Limiter to monitor our requests
+// This is not required if you end up making your own thing.
 func SetupRateLimiter(enabled bool) ratelimit.Limiter {
 	limiter := ratelimit.NewRateLimiter(enabled)
 
@@ -35,42 +36,12 @@ func SetupRateLimiter(enabled bool) ratelimit.Limiter {
 type ApiClient interface {
 	NewRequest(string) ApiRequest
 	ChangeRegion(Region)
+	Get(ApiRequest) (*http.Response, error)
 }
 
 type ApiRequest interface {
-	Get(interface{}) *errors.RequestError
 	AddParameter(string, string)
 	SetParameters(url.Values)
-}
-
-func NewClient(region Region, enabled bool) ApiClient {
-	var rateLimiter ratelimit.Limiter
-	if enabled {
-		rateLimiter = SetupRateLimiter(enabled)
-	}
-
-	return &RiotClient{
-		rateLimitEnabled: enabled,
-		region:           region,
-		limiter:          rateLimiter,
-	}
-}
-
-func isBad(code int) bool {
-	return (code >= 200 && code < 300) != true
-}
-
-func get(u *url.URL) (resp *http.Response, err error) {
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return resp, err
-	}
-
-	req.Header.Add("X-Riot-Token", c.Token)
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, nil
+	Encode() string
+	Uri() string
 }

--- a/riot/v3/champions/api.go
+++ b/riot/v3/champions/api.go
@@ -10,6 +10,11 @@ var buildUri = v3.BuildUriFunc(`platform`)
 func FreeChampions(c riot.ApiClient) (ci ChampionInfo, err error) {
 	req := c.NewRequest(buildUri(`champion-rotations`))
 
-	req.Get(&ci)
+	resp, err := c.Get(req)
+	if err != nil {
+		return ci, err
+	}
+
+	err = riot.GetResultFromResp(resp, &ci)
 	return ci, err
 }

--- a/riot/v4/leagues/api.go
+++ b/riot/v4/leagues/api.go
@@ -13,7 +13,12 @@ var buildUri = v4.BuildUriFunc(`league`)
 func getLeague(c riot.ApiClient, endpoint string) (league League, err error) {
 	req := c.NewRequest(buildUri(endpoint))
 
-	req.Get(&league)
+	resp, err := c.Get(req)
+	if err != nil {
+		return league, err
+	}
+
+	err = riot.GetResultFromResp(resp, &league)
 	return league, err
 }
 
@@ -23,7 +28,12 @@ func getEntries(c riot.ApiClient, endpoint string, page int) (entries []LeagueEn
 		req.AddParameter(`page`, strconv.Itoa(page))
 	}
 
-	err = req.Get(&entries)
+	resp, err := c.Get(req)
+	if err != nil {
+		return entries, err
+	}
+
+	err = riot.GetResultFromResp(resp, entries)
 	return entries, err
 }
 

--- a/riot/v4/mastery/api.go
+++ b/riot/v4/mastery/api.go
@@ -9,24 +9,39 @@ import (
 
 var makeUri = v4.BuildUriFunc(`champion-mastery`)
 
-func All(c riot.ApiClient, id string) (cm []ChampionMastery, err error) {
-	req := c.NewRequest(makeUri(`champion-masteries/by-summoner/` + id))
-
-	err = req.Get(&cm)
-	return cm, err
-}
-
 func Score(c riot.ApiClient, id string) (score int, err error) {
 	req := c.NewRequest(makeUri(`champion-masteries/by-summoner/` + id))
 
-	err = req.Get(&score)
+	resp, err := c.Get(req)
+	if err != nil {
+		return score, err
+	}
+
+	err = riot.GetResultFromResp(resp, &score)
 	return score, err
+}
+
+func All(c riot.ApiClient, id string) (cm []ChampionMastery, err error) {
+	req := c.NewRequest(makeUri(`champion-masteries/by-summoner/` + id))
+
+	resp, err := c.Get(req)
+	if err != nil {
+		return ci, err
+	}
+
+	err = riot.GetResultFromResp(resp, &cm)
+	return cm, err
 }
 
 func ByChampionId(c riot.ApiClient, id string, championId int) (cm ChampionMastery, err error) {
 	endpoint := fmt.Sprintf(`champion-masteries/by-summoner/%s/by-champion/%d`, id, championId)
 	req := c.NewRequest(makeUri(endpoint))
 
-	err = req.Get(&cm)
+	resp, err := c.Get(req)
+	if err != nil {
+		return cm, err
+	}
+
+	err = riot.GetResultFromResp(resp, &cm)
 	return cm, err
 }

--- a/riot/v4/matches/api.go
+++ b/riot/v4/matches/api.go
@@ -16,7 +16,12 @@ func GetMatchlists(c riot.ApiClient, id string, values url.Values) (matches Matc
 	req := c.NewRequest(uri)
 	req.SetParameters(values)
 
-	req.Get(&matches)
+	resp, err := c.Get(req)
+	if err != nil {
+		return matches, err
+	}
+
+	err = riot.GetResultFromResp(resp, &matches)
 	return matches, err
 }
 
@@ -24,7 +29,12 @@ func GetMatch(c riot.ApiClient, match_id string) (match Match, err error) {
 	uri := buildUri("matches/" + match_id)
 	req := c.NewRequest(uri)
 
-	err = req.Get(&match)
+	resp, err := c.Get(req)
+	if err != nil {
+		return match, err
+	}
+
+	err = riot.GetResultFromResp(resp, &match)
 	return match, err
 }
 
@@ -32,6 +42,11 @@ func GetTimeline(c riot.ApiClient, match_id string) (tl Timeline, err error) {
 	uri := buildUri("timelines/by-match/" + match_id)
 	req := c.NewRequest(uri)
 
-	err = req.Get(&tl)
+	resp, err := c.Get(req)
+	if err != nil {
+		return tl, err
+	}
+
+	err = riot.GetResultFromResp(resp, &tl)
 	return tl, err
 }

--- a/riot/v4/summoner/api.go
+++ b/riot/v4/summoner/api.go
@@ -9,7 +9,13 @@ var buildUri = v4.BuildUriFunc(`summoner`)
 
 func get(c riot.ApiClient, endpoint string) (summoner Summoner, err error) {
 	req := c.NewRequest(buildUri(endpoint))
-	req.Get(&summoner)
+
+	resp, err := c.Get(req)
+	if err != nil {
+		return summoner, err
+	}
+
+	err = riot.GetResultFromResp(resp, &summoner)
 	return summoner, err
 }
 


### PR DESCRIPTION
Learned a valuable lesson today. 

Any struct that has Error func implemented on it, it will cause a `null` value.